### PR TITLE
linter configured for airbnb style guide

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    "extends": "airbnb-base",
+    "plugins": [
+        "import"
+    ]
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -16,5 +16,10 @@
   "bugs": {
     "url": "https://github.com/dweill/green-field/issues"
   },
-  "homepage": "https://github.com/dweill/green-field#readme"
+  "homepage": "https://github.com/dweill/green-field#readme",
+  "devDependencies": {
+    "eslint": "^4.0.0",
+    "eslint-config-airbnb-base": "^11.2.0",
+    "eslint-plugin-import": "^2.5.0"
+  }
 }


### PR DESCRIPTION
linter configured for airbnb style guide, added node_modules to .gitignore, installed eslint as a dev dependency in package.json